### PR TITLE
Feature/fix python3.6 compatibility issue

### DIFF
--- a/pp_api/models/models.py
+++ b/pp_api/models/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, asdict
-from typing import Dict, Any
+from typing import Dict, Any, List
 
 
 @dataclass
@@ -8,7 +8,7 @@ class PoolPartyProject:
     title: str
     userGroups: []
     author: str = None
-    availableLanguages: list[str] = field(default_factory=list)
+    availableLanguages: List[str] = field(default_factory=list)
     baseUrl: str = None
     contributor: str = None
     description: str = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ urllib3
 setuptools
 oauthlib
 requests_oauthlib
+dataclasses; python_version == '3.6'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ dependencies = ["https://github.com/Project-PROFIT/nif.git@origin/master#egg=nif
 
 setup(
     name='pp_api',
-    version='18.1.0',
+    version='18.1.1',
     description='Library for accessing PoolParty APIs',
     packages=['pp_api', 'pp_api.models'],
     license='MIT',


### PR DESCRIPTION
c86d14835302679d3a1f45cda2314a067bbf8fc5 introduced the use of dataclasses, which only available since python 3.7. Additionally, there was an issue on the declaration of the PoolPartyProject dataclass raising a type error in python versions prior to 3.9. This PR resolves those issues. 